### PR TITLE
Remocao de pokemon com nomes iguais feita e Mostrar pokemon com nome igual

### DIFF
--- a/CRUD.h
+++ b/CRUD.h
@@ -18,7 +18,7 @@ public:
 private:
     void grava();
     void recupera();
-    int indice(string nome);
+    vector<int>* indice(string nome);
 
     string fileName;
     vector<Pokemon *> pokemons;


### PR DESCRIPTION
A funcao de indice, a qual encontrava apenas o primeiro pokemon agora gera um vetor com todas as ocorrências, isso é repassado às funções subsequentes e tratado para, na remoção, escolher o pokemon dentre os encontrados e, na visualização, mostrar todas as ocorrências